### PR TITLE
add install pip command instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ jupyter notebook
 
 7. Run the commands in [generate.ipynb] to generate images.
 
-9. First time you run notebook, it will ask you to install ipykernel, accept this.
+8. First time you run notebook, it will ask you to install ipykernel, accept this.
  
-10. If the program executes successfully, it will output all the generated images to the /images folder, and the metadata to the /metadata folder. The filenames will refer to tokenIds. 
+9. If the program executes successfully, it will output all the generated images to the /images folder, and the metadata to the /metadata folder. The filenames will refer to tokenIds. 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 
+
 ## About
 Python Notebook in Jupyter that will generate a series of unique images using a collection of layers.
 
@@ -6,14 +7,12 @@ Python Notebook in Jupyter that will generate a series of unique images using a 
 1. Install [Python](https://www.python.org/downloads/)
 
 2. Install PIP
-	Download PIP get-pip.py
-	  ```
-	curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-	```
-	Install PIP
-	```
-	python get-pip.py
-	```
+Download PIP get-pip.py
+```
+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+
+python get-pip.py
+```
 
 3. Install Python Pillow
 ```
@@ -25,6 +24,18 @@ pip install pillow
 pip install display
 ```
 
-5. First time you run notebook, it will ask you to install ipykernel, accept this.
+5. Install Jupyter Notebook
+```
+pip install jupyter 
+```
+
+6. Run Jupyter in your nft-image-generator folder
+```
+jupyter notebook
+```
+
+7. Run the commands in [generate.ipynb] to generate images.
+
+9. First time you run notebook, it will ask you to install ipykernel, accept this.
  
-6. If the program executes successfully, it will output all the generated images to the /images folder, and the metadata to the /metadata folder. The filenames will refer to tokenIds. 
+10. If the program executes successfully, it will output all the generated images to the /images folder, and the metadata to the /metadata folder. The filenames will refer to tokenIds. 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,30 @@
+
 ## About
 Python Notebook in Jupyter that will generate a series of unique images using a collection of layers.
 
 ## Getting Started
 1. Install [Python](https://www.python.org/downloads/)
 
-2. Install Python Pillow
+2. Install PIP
+	Download PIP get-pip.py
+	  ```
+	curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+	```
+	Install PIP
+	```
+	python get-pip.py
+	```
+
+3. Install Python Pillow
 ```
 pip install pillow
 ```
 
-3. Install Python display
+4. Install Python display
 ```
 pip install display
 ```
 
-4. First time you run notebook, it will ask you to install ipykernel, accept this.
+5. First time you run notebook, it will ask you to install ipykernel, accept this.
  
-5. If the program executes successfully, it will output all the generated images to the /images folder, and the metadata to the /metadata folder. The filenames will refer to tokenIds. 
+6. If the program executes successfully, it will output all the generated images to the /images folder, and the metadata to the /metadata folder. The filenames will refer to tokenIds. 


### PR DESCRIPTION


## About
Python Notebook in Jupyter that will generate a series of unique images using a collection of layers.

## Getting Started
1. Install [Python](https://www.python.org/downloads/)

2. Install PIP
Download PIP get-pip.py
```
curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py

python get-pip.py
```

3. Install Python Pillow
```
pip install pillow
```

4. Install Python display
```
pip install display
```

5. Install Jupyter Notebook
```
pip install jupyter 
```

6. Run Jupyter in your nft-image-generator folder
```
jupyter notebook
```

7. Run the commands in [generate.ipynb] to generate images.

9. First time you run notebook, it will ask you to install ipykernel, accept this.
 
10. If the program executes successfully, it will output all the generated images to the /images folder, and the metadata to the /metadata folder. The filenames will refer to tokenIds. 
